### PR TITLE
Adds Basic and Bronstein Delay Timer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import setup, find_packages
 
 setup(
-    version="0.14.0",
+    version="0.15.0",
     setup_requires=[],
     test_require=[],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import setup, find_packages
 
 setup(
-    version="0.13.0",
+    version="0.14.0",
     setup_requires=[],
     test_require=[],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import setup, find_packages
 
 setup(
-    version="0.15.0",
+    version="0.16.0",
     setup_requires=[],
     test_require=[],
     include_package_data=True,

--- a/src/chesster/cli/__init__.py
+++ b/src/chesster/cli/__init__.py
@@ -71,7 +71,7 @@ def save_board(board:chess.Board, board_dir:str, width:int, height:int) -> str:
     return save_name
 
 
-def main(white:str, black:str, timer:str="IncrementTimer", 
+def main(white:str, black:str, timer:str="BronsteinDelayTimer", 
         start_seconds:int=600, increment_seconds:int=2, board_dir:str=None,
         frame_dir:str=None, output_gif:str=None, width:int=400,
         height:int=600) -> int:
@@ -83,7 +83,7 @@ def main(white:str, black:str, timer:str="IncrementTimer",
         The name of the AI for the white player.
     black: str
         The name of the AI for the black player.
-    timer: str="IncrementTimer"
+    timer: str="BronsteinDelayTimer"
         The name of the timer for each player.
     start_seconds: float=600
         The number of seconds to start the timer at.
@@ -369,7 +369,7 @@ def parse_arguments(args=None) -> None:
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("white", help="The AI for the white player.")
     parser.add_argument("black", help="The AI for the white player.")
-    parser.add_argument("--timer", default="IncrementTimer",
+    parser.add_argument("--timer", default="BronsteinDelayTimer",
             help="The timer to use for players.")
     parser.add_argument("--start_seconds", default=600, type=float,
             help="The number of seconds to star the timer at.")

--- a/src/chesster/timer/__init__.py
+++ b/src/chesster/timer/__init__.py
@@ -1,8 +1,11 @@
 """Timer module for Chesster
 The basic timer is the API for all other timers.
 """
+from .basic import BasicTimer
 from .increment import IncrementTimer
 
+
 timers = {
+    BasicTimer.__name__: BasicTimer,
     IncrementTimer.__name__: IncrementTimer
 }

--- a/src/chesster/timer/__init__.py
+++ b/src/chesster/timer/__init__.py
@@ -2,10 +2,12 @@
 The basic timer is the API for all other timers.
 """
 from .basic import BasicTimer
+from .bronstein import BronsteinDelayTimer
 from .increment import IncrementTimer
 
 
 timers = {
     BasicTimer.__name__: BasicTimer,
+    BronsteinDelayTimer.__name__: BronsteinDelayTimer,
     IncrementTimer.__name__: IncrementTimer
 }

--- a/src/chesster/timer/base.py
+++ b/src/chesster/timer/base.py
@@ -8,7 +8,7 @@ class TimerError(Exception):
 
 
 class BaseTimer(abc.ABC):
-    def __init__(self, start_seconds:float):
+    def __init__(self, start_seconds:float, increment_seconds:float):
         """BaseTimer
 
         Parameters
@@ -19,6 +19,7 @@ class BaseTimer(abc.ABC):
         self._seconds_left = start_seconds
         self._start_time = None
         self._time_clocked = 0
+        self._increment_seconds = increment_seconds
 
 
     @property
@@ -46,6 +47,19 @@ class BaseTimer(abc.ABC):
 
 
     @property
+    def incrment_seconds(self) -> float:
+        """Return the number of seconds that is added to the timer after each 
+        move.
+
+        Returns
+        -------
+        float
+            The number of seconds that is added to the timer after each move.
+        """
+        return self._increment_seconds
+
+
+    @property
     def time_clocked(self) -> float:
         """Return the number of seconds the timer has clocked
 
@@ -57,6 +71,28 @@ class BaseTimer(abc.ABC):
         return self._time_clocked + self._elapsed_seconds()
 
 
+    @staticmethod
+    def seconds_to_string(seconds: float) -> str:
+        """Return nicely formatted string of minutes, seconds, and milliseconds
+
+        Parameters
+        ----------
+        seconds: float
+            The number of seconds to convert
+
+        Returns
+        -------
+        str
+            The converted seconds
+        """
+        # Calculate the minutes and seconds
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        milliseconds = int(seconds % 60 % 1 * 100)
+        # Return formatted text
+        return f"{minutes:02}:{secs:02}:{milliseconds:02}"
+
+
     def display_time(self) -> str:
         """Return nicely formatted string of minutes and seconds left.
 
@@ -65,14 +101,7 @@ class BaseTimer(abc.ABC):
         str
             The number of minutes and seconds left on the timer
         """
-        # Get the time left at this exact moment of the method call
-        seconds_left = self.seconds_left
-        # Calculate the minutes and seconds
-        minutes = int(seconds_left // 60)
-        seconds = int(seconds_left % 60)
-        milliseconds = int(seconds_left % 60 % 1 * 100)
-        # Return formatted text
-        return f"{minutes:02}:{seconds:02}:{milliseconds:02}"
+        return self.seconds_to_string(self.seconds_left)
 
 
     def start(self) -> None:

--- a/src/chesster/timer/base.py
+++ b/src/chesster/timer/base.py
@@ -88,8 +88,13 @@ class BaseTimer(abc.ABC):
         self._start_time = time.perf_counter()
 
 
-    def stop(self) -> None:
+    def stop(self) -> float:
         """Stop the timer
+
+        Returns
+        -------
+        float
+            The number of seconds that passed from start to stop.
 
         Raises
         ------
@@ -102,6 +107,8 @@ class BaseTimer(abc.ABC):
         self._seconds_left -= elapsed
         self._time_clocked += elapsed
         self._start_time = None
+        # Return the number of seconds that elapsed
+        return elapsed
 
 
     def _elapsed_seconds(self) -> float:

--- a/src/chesster/timer/basic.py
+++ b/src/chesster/timer/basic.py
@@ -4,10 +4,21 @@ import numpy as np
 
 
 class BasicTimer(BaseTimer):
-    def __init__(self):
+    def __init__(self, *args):
         """BasicTimer
         Only keeps track of how much time has been used. It will thus never
         die.
         """
-        super().__init__(np.inf)
+        super().__init__(np.inf, 0)
+
+
+    def display_time(self) -> str:
+        """Return nicely formatted string of minutes and seconds used.
+
+        Returns
+        -------
+        str
+            The number of minutes and seconds clocked on the timer
+        """
+        return self.seconds_to_string(self.time_clocked)
 

--- a/src/chesster/timer/basic.py
+++ b/src/chesster/timer/basic.py
@@ -1,0 +1,13 @@
+"""Basic timer object for Chesster."""
+from .base import BaseTimer
+import numpy as np
+
+
+class BasicTimer(BaseTimer):
+    def __init__(self):
+        """BasicTimer
+        Only keeps track of how much time has been used. It will thus never
+        die.
+        """
+        super().__init__(np.inf)
+

--- a/src/chesster/timer/bronstein.py
+++ b/src/chesster/timer/bronstein.py
@@ -15,21 +15,7 @@ class BronsteinDelayTimer(BaseTimer):
         increment_seconds: float
             The maximum number of seconds to increment after each move.
         """
-        super().__init__(start_seconds)
-        self._increment_seconds = increment_seconds
-
-
-    @property
-    def incrment_seconds(self) -> float:
-        """Return the number of seconds that is added to the timer after each 
-        move.
-
-        Returns
-        -------
-        float
-            The number of seconds that is added to the timer after each move.
-        """
-        return self._increment_seconds
+        super().__init__(start_seconds, increment_seconds)
 
 
     def stop(self) -> None:

--- a/src/chesster/timer/bronstein.py
+++ b/src/chesster/timer/bronstein.py
@@ -1,0 +1,53 @@
+"""Bronstein delay timer object for Chesster."""
+from .base import BaseTimer
+
+
+class BronsteinDelayTimer(BaseTimer):
+    def __init__(self, start_seconds:float, increment_seconds:float):
+        """BronsteinDelayTimer
+
+        Implements the Bronstein delay timer
+
+        Parameters
+        ----------
+        start_seconds: float
+            The number of seconds the timer starts with.
+        increment_seconds: float
+            The maximum number of seconds to increment after each move.
+        """
+        super().__init__(start_seconds)
+        self._increment_seconds = increment_seconds
+
+
+    @property
+    def incrment_seconds(self) -> float:
+        """Return the number of seconds that is added to the timer after each 
+        move.
+
+        Returns
+        -------
+        float
+            The number of seconds that is added to the timer after each move.
+        """
+        return self._increment_seconds
+
+
+    def stop(self) -> None:
+        """Stop the timer
+
+        Raises
+        ------
+        TimerError
+            Raised if the timer is already running.
+        """
+        elapsed = super().stop()
+        # Check that the clock hasn't expired
+        if self.alive:
+            # Check that the elapsed seconds is more or equal to the increment
+            if elapsed >= self._increment_seconds:
+                # Add the maximum number of seconds
+                self._seconds_left += self._increment_seconds
+            else:
+                # Add only the number of seconds used
+                self._seconds_left += elapsed
+

--- a/src/chesster/timer/increment.py
+++ b/src/chesster/timer/increment.py
@@ -13,8 +13,7 @@ class IncrementTimer(BaseTimer):
         increment_seconds: float
             The number of seconds to increment after each move.
         """
-        super().__init__(start_seconds)
-        self._increment_seconds = increment_seconds
+        super().__init__(start_seconds, increment_seconds)
 
 
     @property


### PR DESCRIPTION
The Basic timer simply keeps track of the clocked time. The Bronstein dealy is a common chess timer. It's now set as the default timer as it prevents fast players from accruing extra time.